### PR TITLE
Fix link to docker section from TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
     - [Fast Packet Processing](#fast-packet-processing)
     - [Firewall](#firewall)
     - [Anti-Spam](#anti-spam)
-    - [Docker](#docker)
+    - [Docker](#docker-images-for-penetration-testing--security)
   - [Endpoint](#endpoint)
     - [Anti-Virus / Anti-Malware](#anti-virus--anti-malware)
   - [Threat Intelligence](#threat-intelligence)


### PR DESCRIPTION
That’s it :octocat: 