### PR TITLE
Add padding-oracle-attacker

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [PTF](https://github.com/trustedsec/ptf) - The Penetration Testers Framework (PTF) is a way for modular support for up-to-date tools.
 - [Infection Monkey](https://github.com/guardicore/monkey) - A semi automatic pen testing tool for mapping/pen-testing networks. Simulates a human attacker.
 - [ACSTIS](https://github.com/tijme/angularjs-csti-scanner) - ACSTIS helps you to scan certain web applications for AngularJS Client-Side Template Injection (sometimes referred to as CSTI, sandbox escape or sandbox bypass). It supports scanning a single request but also crawling the entire web application for the AngularJS CSTI vulnerability.
+- [padding-oracle-attacker](https://github.com/KishanBagaria/padding-oracle-attacker) - padding-oracle-attacker is a CLI tool and library to execute padding oracle attacks (which decrypts data encrypted in CBC mode) easily, with support for concurrent network requests and an elegant UI.
 
 ### Runtime Application Self-Protection
 


### PR DESCRIPTION
padding-oracle-attacker is a CLI tool and library to execute padding oracle attacks easily, with support for concurrent network requests and an elegant UI.

https://github.com/KishanBagaria/padding-oracle-attacker

![poattack demo](https://raw.githubusercontent.com/KishanBagaria/padding-oracle-attacker/master/media/poattack-decrypt.gif)