### PR TITLE
Add Stegcloak 

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 ### Authentication
 
 - [google-authenticator](https://github.com/google/google-authenticator) - The Google Authenticator project includes implementations of one-time passcode generators for several mobile platforms, as well as a pluggable authentication module (PAM). One-time passcodes are generated using open standards developed by the Initiative for Open Authentication (OATH) (which is unrelated to OAuth). These implementations support the HMAC-Based One-time Password (HOTP) algorithm specified in RFC 4226 and the Time-based One-time Password (TOTP) algorithm specified in RFC 6238. [Tutorials: How to set up two-factor authentication for SSH login on Linux](http://xmodulo.com/two-factor-authentication-ssh-login-linux.html)
-- [Stegcloak](https://github.com/kurolabs/stegcloak) - Assign digital authenticity to any written text
+- [Stegcloak](https://github.com/kurolabs/stegcloak) - Securely assign Digital Authenticity to any written text
 
 ### Mobile / Android / iOS
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 ### Authentication
 
 - [google-authenticator](https://github.com/google/google-authenticator) - The Google Authenticator project includes implementations of one-time passcode generators for several mobile platforms, as well as a pluggable authentication module (PAM). One-time passcodes are generated using open standards developed by the Initiative for Open Authentication (OATH) (which is unrelated to OAuth). These implementations support the HMAC-Based One-time Password (HOTP) algorithm specified in RFC 4226 and the Time-based One-time Password (TOTP) algorithm specified in RFC 6238. [Tutorials: How to set up two-factor authentication for SSH login on Linux](http://xmodulo.com/two-factor-authentication-ssh-login-linux.html)
+- [Stegcloak](https://github.com/kurolabs/stegcloak) - Assign digital authenticity to any written text
 
 ### Mobile / Android / iOS
 


### PR DESCRIPTION
Stegcloak can hide secrets in strings by compressing and encrypting the secret with an AES-256 stream cipher before cloaking it with special Unicode invisible characters.

Protecting copyrights by text-steganography:
https://www.theverge.com/2019/12/3/20993621/genius-google-lawsuit-stolen-lyrics-lyricfind

Stegcloak allows users to assign digital authenticity to any written text.
