### PR TITLE
Add Acra to Datastores

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 
 ## Datastores
 
+- [acra](https://github.com/cossacklabs/acra) - Database security suite: proxy for data protection with transparent "on the fly" data encryption, data masking and tokenization, SQL firewall (SQL injections prevention), intrusion detection system.
 - [blackbox](https://github.com/StackExchange/blackbox) - Safely store secrets in a VCS repo using GPG
 - [confidant](https://github.com/lyft/confidant) - Stores secrets in AWS DynamoDB, encrypted at rest and integrates with IAM
 - [dotgpg](https://github.com/ConradIrwin/dotgpg) - A tool for backing up and versioning your production secrets or shared passwords securely and easily.


### PR DESCRIPTION
[Acra](https://github.com/cossacklabs/acra) is a database security proxy that helps developer to encrypt data before storing in the database ("transparent field level encryption"). Works with SQL and NoSQL data stores.