### PR TITLE
Add UDcide, an Android malware behavior editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [hardened_malloc](https://github.com/GrapheneOS/hardened_malloc) - Hardened allocator designed for modern systems. It has integration into Android's Bionic libc and can be used externally with musl and glibc as a dynamic library for use on other Linux-based platforms. It will gain more portability / integration over time.
 - [AMExtractor](https://github.com/ir193/AMExtractor) - AMExtractor can dump out the physical content of your Android device even without kernel source code.
 - [frida](https://github.com/frida/frida) - Dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers.
+- [UDcide](https://github.com/UDcide/udcide) - Android Malware Behavior Editor.
 
 ### Forensics
 


### PR DESCRIPTION
UDcide is a tool that provides alternative way to deal with Android malware. We help you to detect and remove specific behaviors in the malware rather than just delete the whole binary. And surprisingly, we make the binary runs still. This enables possibilities of malware research and makes good use of the normal behaviors in the malware.