### PR TITLE
Add ThreatJammer.com to the Threat Intel list

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [CIFv2](https://github.com/csirtgadgets/massive-octo-spice) - CIF is a cyber threat intelligence management system. CIF allows you to combine known malicious threat information from many sources and use that information for identification (incident response), detection (IDS) and mitigation (null route).
 - [MISP - Open Source Threat Intelligence Platform ](https://www.misp-project.org/) - MISP threat sharing platform is a free and open source software helping information sharing of threat intelligence including cyber security indicators.  A threat intelligence platform for gathering, sharing, storing and correlating Indicators of Compromise of targeted attacks, threat intelligence, financial fraud information, vulnerability information or even counter-terrorism information. The MISP project includes software, common libraries ([taxonomies](https://www.misp-project.org/taxonomies.html), [threat-actors and various malware](https://www.misp-project.org/galaxy.html)), an extensive data model to share new information using [objects](https://www.misp-project.org/objects.html) and default [feeds](https://www.misp-project.org/feeds/).
 - [PhishStats](https://phishstats.info/) - Phishing Statistics with search for IP, domain and website title.
+- [Threat Jammer](https://threatjammer.com) - REST API service that allows developers, security engineers, and other IT professionals to access curated threat intelligence data from a variety of sources.
 
 ## Social Engineering
 


### PR DESCRIPTION
I hope this new service is valuable to the threat intel community and security professionals.

I have added the service at the end of the list. I was not able to figure out if there was any specific sorting (lexicographic or newer entries at the bottom). Sorry if I was wrong. 