### PR TITLE
Adds MutableSecurity to a New Category

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,10 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Redcloud](https://github.com/khast3x/Redcloud) - A automated Red Team Infrastructure deployement using Docker.
 - [Axiom](https://github.com/pry0cc/axiom) -Axiom is a dynamic infrastructure framework to efficiently work with multi-cloud environments, build and deploy repeatable infrastructure focussed on offensive and defensive security.
 
+## Blue Team Infrastructure Deployment
+
+- [MutableSecurity](https://github.com/MutableSecurity/mutablesecurity) - CLI program for automating the setup, configuration, and use of cybersecurity solutions.
+
 ## Usability
 
 - [Usable Security Course](https://pt.coursera.org/learn/usable-security) - Usable Security course at coursera. Quite good for those looking for how security and usability intersects.


### PR DESCRIPTION
The pull request adds [MutableSecurity](https://github.com/MutableSecurity/mutablesecurity), a CLI tool for managing the lifecycle of cybersecurity solutions, to a new Blue Team Infrastructure Deployment category.