### PR TITLE
📦 Add link-checking action

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Run linksafe
         uses: TechWiz-3/linksafe@fast
+        with:
+          whitelist_links: "http://www.clamav.net/,https://www.cipherdyne.org/fwknop/,http://bruteforce.gr/honeydrive,https://ossec.github.io/"
         env:
           TOKEN: ${{ secrets.TOKEN }}
         

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,15 @@
+name: Link-check
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # every monday
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run linksafe
+        uses: TechWiz-3/linksafe@fast
+        env:
+          TOKEN: ${{ secrets.TOKEN }}
+        

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Run linksafe
         uses: TechWiz-3/linksafe@fast
         with:
-          whitelist_links: "http://www.clamav.net/,https://www.cipherdyne.org/fwknop/,http://bruteforce.gr/honeydrive,https://ossec.github.io/"
+          whitelist_links: "http://www.clamav.net/,https://www.cipherdyne.org/fwknop/,http://bruteforce.gr/honeydrive,https://ossec.github.io/,https://www.hardenwindows10forsecurity.com/"
         env:
           TOKEN: ${{ secrets.TOKEN }}
         


### PR DESCRIPTION
In this PR, I have added a workflow which checks links and fails if any of them are broken.

Disclaimer: this action is my own, the repo is [here](https://github.com/TechWiz-3/linksafe/tree/fast).

Because of the large volume of links, I'm using the 'fast' version/branch which simply requires a GitHub token (with no extra perms) to be stored as a repo secret under the name  `TOKEN`. This is for requests to the GitHub API to avoid rate-limits. More setup info [here](https://github.com/TechWiz-3/linksafe/tree/fast#setup)

You can view the logs of the workflow on my fork [here](
https://github.com/TechWiz-3/awesome-security/actions/runs/3270619740/jobs/5379453613). **8** links were found to be broken.

The workflow is run every Monday and on `push`.

Let me know if you'd like me to change anything, any feedback is appreciated either way :)

<img width="405" alt="Screen Shot 2022-10-19 at 11 41 21 am" src="https://user-images.githubusercontent.com/75515581/196570901-c8df2cba-5559-49d6-b4db-e57c41b0d8b0.png">
