### PR TITLE
Add Squey

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Rekall](https://github.com/google/rekall) - The Rekall Framework is a completely open collection of tools, implemented in Python under the Apache and GNU General Public License, for the extraction and analysis of digital artifacts computer systems.
 - [LiME](https://github.com/504ensicsLabs/LiME.git) - Linux Memory Extractor
 - [Maigret](https://github.com/soxoj/maigret) - Maigret collect a dossier on a person by username only, checking for accounts on a huge number of sites and gathering all the available information from web pages.
+- [Squey](https://squey.org) - Logs/PCAP visualization software designed to explore large amount of data to detect anomalies and weak signals.
 
 ## Threat Intelligence
 


### PR DESCRIPTION
Add Squey to Endpoint/Forensics section.

See https://squey.org/domains/cybersecurity/

Disclaimer : I am one of the project developer.