### PR TITLE
feat: add new tool for cognito pentest

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Netz](https://github.com/spectralops/netz)- Discover internet-wide misconfigurations, using zgrab2 and others.
 - [Deepfence ThreatMapper](https://github.com/deepfence/ThreatMapper) - Apache v2, powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
 - [Deepfence SecretScanner](https://github.com/deepfence/SecretScanner) - Find secrets and passwords in container images and file systems.
-
+- [Cognito Scanner](https://github.com/padok-team/cognito-scanner) - CLI tool to pentest Cognito AWS instance. It implements three attacks: unwanted account creation, account oracle and identity pool escalation
 
 ### Monitoring / Logging
 - [BoxyHQ](https://github.com/retracedhq/retraced) - Open source API for security and compliance audit logging.


### PR DESCRIPTION
Cognito Scanner is a CLI open-source tool. It enables to pentest Cognito AWS instance easily. It can be installed through a python package