### PR TITLE
Added ipapi.is to the Threat Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [PhishStats](https://phishstats.info/) - Phishing Statistics with search for IP, domain and website title.
 - [Threat Jammer](https://threatjammer.com) - REST API service that allows developers, security engineers, and other IT professionals to access curated threat intelligence data from a variety of sources.
 - [Cyberowl](https://github.com/karimhabush/cyberowl) - A daily updated summary of the most frequent types of security incidents currently being reported from different sources.
+- [ipapi.is](https://ipapi.is) - Ipapi.is is a reliable IP Address API from Developers for Developers with accurate Hosting Detection, IP Geolocation, IP to Organisation and ASN data.
 
 ## Social Engineering
 


### PR DESCRIPTION
I think ipapi.is makes sense to be added to the Threat Intelligence section, since it allows security specialists to obtain useful meta data about any IP address