### PR TITLE
Add GeoNetstat

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Deepfence ThreatMapper](https://github.com/deepfence/ThreatMapper) - Apache v2, powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
 - [Deepfence SecretScanner](https://github.com/deepfence/SecretScanner) - Find secrets and passwords in container images and file systems.
 - [Cognito Scanner](https://github.com/padok-team/cognito-scanner) - CLI tool to pentest Cognito AWS instance. It implements three attacks: unwanted account creation, account oracle and identity pool escalation
+- [GeoNetstat](https://github.com/globalcve/geonetstat) – Geo-enriched netstat/ss with ncurses interface for network visibility and logging.
 
 ### Monitoring / Logging
 - [BoxyHQ](https://github.com/retracedhq/retraced) - Open source API for security and compliance audit logging.


### PR DESCRIPTION
#### New Tool Submission

- [x] I've read the [awesome manifesto](https://github.com/sindresorhus/awesome/blob/main/awesome.md) and the contribution guidelines.

**Repo or homepage link:**
https://github.com/globalcve/geonetstat

**Description:**
Geo-enriched netstat/ss with ncurses interface for network visibility and security monitoring.

**Why I think it's awesome:**
GeoNetstat extends traditional netstat/ss by enriching connections with geolocation data and presenting them in a clear ncurses interface. This makes it easier for security engineers and sysadmins to quickly identify suspicious connections, monitor traffic origins, and improve situational awareness. It’s open source, well documented, and actively maintained, making it a practical addition to the Monitoring / Logging category.
