### PR TITLE
Add react2shell-scanner and shai-hulud-scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [recon](https://github.com/rusty-ferris-club/recon) - a fast Rust based CLI that uses SQL to query over files, code, or malware with content classification and processing for security experts
 - [CakeFuzzer](https://github.com/Zigrin-Security/CakeFuzzer) - The ultimate web application security testing tool for CakePHP-based web applications. CakeFuzzer employs a predefined set of attacks that are randomly modified before execution. Leveraging its deep understanding of the Cake PHP framework, Cake Fuzzer launches attacks on all potential application entry points.
 - [Artemis](https://github.com/CERT-Polska/Artemis/) - A modular vulnerability scanner with automatic report generation capabilities.
+- [react2shell-scanner](https://github.com/nxgn-kd01/react2shell-scanner) - Detect CVE-2025-55182 (React2Shell) RCE vulnerability in React Server Components. Scans React 19.x and Next.js projects for critical remote code execution flaws.
+- [shai-hulud-scanner](https://github.com/nxgn-kd01/shai-hulud-scanner) - Detect indicators of compromise from the Shai Hulud 2.0 npm supply chain attack that compromised 796+ packages. Performs comprehensive security checks for malicious files, hashes, and patterns.
 
 ### Runtime Application Self-Protection
 


### PR DESCRIPTION
## Security Vulnerability Scanners

This PR adds two new security scanning tools:

### react2shell-scanner
- **Repository:** https://github.com/nxgn-kd01/react2shell-scanner  
- **Purpose:** Detects CVE-2025-55182 (React2Shell) RCE vulnerability
- **Features:** Scans React 19.x and Next.js projects for critical remote code execution flaws
- **CVSS:** 10.0 (CRITICAL)

### shai-hulud-scanner
- **Repository:** https://github.com/nxgn-kd01/shai-hulud-scanner
- **Purpose:** Detects Shai Hulud 2.0 npm supply chain attack indicators
- **Features:** Comprehensive security checks for malicious files, hashes, and patterns in 796+ compromised npm packages

Both tools are actively maintained, open-source (MIT license), and help developers identify critical security vulnerabilities in Node.js/React ecosystems.

Added to the **Scanning / Pentesting** section.