### PR TITLE
Add Zero Trust API to Content Disarm & Reconstruct section

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 ### Content Disarm & Reconstruct
 
 - [DocBleach](https://github.com/docbleach/DocBleach) - An open-source Content Disarm & Reconstruct software sanitizing Office, PDF and RTF Documents.
+- [Zero Trust API](https://rapidapi.com/image-zero-trust-security-labs/api/zero-trust-api) - Image CDR API that decodes images to raw pixels and rebuilds sterile PNGs, eliminating polyglots, steganography, and image bombs. Built in Rust/WASM.
 
 ### Configuration Management
 


### PR DESCRIPTION
## What is this?

Adding [Zero Trust API](https://rapidapi.com/image-zero-trust-security-labs/api/zero-trust-api) to the Content Disarm & Reconstruct section.

## About Zero Trust API

- **Purpose:** Image CDR (Content Disarm & Reconstruction) for user-uploaded images
- **How it works:** Decodes images to raw RGBA pixels, destroys the original container, and rebuilds a sterile PNG
- **Stack:** Rust core → WebAssembly sandbox → Cloudflare Workers
- **Threats mitigated:** Polyglot files, steganography, image bombs, metadata leaks

## Checklist

- [x] Entry added to bottom of relevant category
- [x] Title is capitalized
- [x] Format follows `[Name](link)` pattern
- [x] Spelling and grammar checked