### PR TITLE
Add PII Firewall Edge to Datastores section

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [passpie](https://github.com/marcwebbie/passpie) - Multiplatform command-line password manager
 - [Vault](https://www.vaultproject.io/) - An encrypted datastore secure enough to hold environment and application secrets.
 - [LunaSec](https://github.com/lunasec-io/lunasec) - Database for PII with automatic encryption/tokenization, sandboxed components for handling data, and centralized authorization controls.
+- [PII Firewall Edge](https://rapidapi.com/image-zero-trust-security-labs/api/pii-firewall-edge) - Edge-deployed PII detection and redaction API supporting 150+ sensitive data types across 50+ countries, using deterministic regex and checksums without AI.
 
 ## Fraud prevention
 


### PR DESCRIPTION
## Description
Adding PII Firewall Edge to the Datastores section as a privacy-focused tool for handling sensitive data.

## About PII Firewall Edge
Edge-deployed PII detection and redaction API supporting 150+ sensitive data types across 50+ countries using deterministic regex and checksums without AI.

**Key features:**
- 150+ PII types (SSN, credit cards, emails, phone numbers, passports)
- 50+ countries supported
- Zero-AI architecture for predictable results
- Sub-5ms latency at edge
- No data storage or logging

**Link:** https://rapidapi.com/image-zero-trust-security-labs/api/pii-firewall-edge