### PR TITLE
Add certgrep and Have I Been Squatted tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Deepfence ThreatMapper](https://github.com/deepfence/ThreatMapper) - Apache v2, powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
 - [Deepfence SecretScanner](https://github.com/deepfence/SecretScanner) - Find secrets and passwords in container images and file systems.
 - [Cognito Scanner](https://github.com/padok-team/cognito-scanner) - CLI tool to pentest Cognito AWS instance. It implements three attacks: unwanted account creation, account oracle and identity pool escalation
+- [Have I Been Squatted](https://haveibeensquatted.com) - A fast domain typosquatting detection tool
+- [certgrep](https://certgrep.sh) - A fast Certificate Transparency Log regex domain lookup tool
 
 ### Monitoring / Logging
 - [BoxyHQ](https://github.com/retracedhq/retraced) - Open source API for security and compliance audit logging.


### PR DESCRIPTION
## Changes

This PR adds two new security tools to the list:

- **[certgrep](https://certgrep.sh)** - A fast Certificate Transparency Log regex domain lookup tool
- **[Have I Been Squatted](https://haveibeensquatted.com)** - A fast domain typosquatting detection tool

These tools are valuable additions for security professionals and researchers.