### PR TITLE
Add SmarterMail CVE-2025-52691 Scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Deepfence ThreatMapper](https://github.com/deepfence/ThreatMapper) - Apache v2, powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
 - [Deepfence SecretScanner](https://github.com/deepfence/SecretScanner) - Find secrets and passwords in container images and file systems.
 - [Cognito Scanner](https://github.com/padok-team/cognito-scanner) - CLI tool to pentest Cognito AWS instance. It implements three attacks: unwanted account creation, account oracle and identity pool escalation
+- [SmarterMail CVE-2025-52691 Scanner](https://github.com/nxgn-kd01/smartermail-cve-scanner) - Fast, accurate scanner for CVE-2025-52691, a critical (CVSS 10.0) unauthenticated RCE vulnerability in SmarterMail servers. Zero dependencies, supports JSON output and CI/CD integration.
 
 ### Monitoring / Logging
 - [BoxyHQ](https://github.com/retracedhq/retraced) - Open source API for security and compliance audit logging.


### PR DESCRIPTION
## Description

Adding [SmarterMail CVE-2025-52691 Scanner](https://github.com/nxgn-kd01/smartermail-cve-scanner) to the Scanning / Pentesting section.

## About the Tool

Fast, accurate scanner for CVE-2025-52691 - a critical (CVSS 10.0) unauthenticated arbitrary file upload vulnerability that enables remote code execution on SmarterMail servers.

**Key Features:**
- Zero dependencies (uses only Node.js built-in modules)
- Dual implementation: Node.js and Bash
- JSON output for automation
- CI/CD integration support
- Read-only scanning (does not attempt exploitation)

## Checklist

- [x] Tool is open source
- [x] Tool is security-related
- [x] Added in alphabetical order within the section
- [x] Description is concise and informative