### PR TITLE
Add NetworkWhois IP Free Blacklist Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [rspamd](https://github.com/rspamd/rspamd) - Fast, free and open-source spam filtering system.
 - [SpamAssassin](https://spamassassin.apache.org/) - A powerful and popular email spam filter employing a variety of detection technique.
 - [Scammer-List](https://scammerlist.now.sh/) - A free open source AI based Scam and Spam Finder with a free API
+- [NetworkWhois IP Blacklist Checker](https://networkwhois.com/ip-blacklist-checker) - Checks an IP against common DNSBLs to troubleshoot email deliverability.
 
 ### Docker Images for Penetration Testing & Security
 


### PR DESCRIPTION
Checks an IP address or a /24 range against common DNSBLs to troubleshoot email deliverability.