### PR TITLE
Add NullSec Linux - Security distribution with 135+ tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Qubes OS](https://www.qubes-os.org/) - Qubes OS is a free and open-source security-oriented operating system meant for single-user desktop computing.
 - [Whonix](https://www.whonix.org) - Operating System designed for anonymity.
 - [Tails OS](https://tails.boum.org/) - Tails is a portable operating system that protects against surveillance and censorship.
+- [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security-focused Linux distribution with 135+ pre-installed tools across cloud, AI/ML, hardware, automotive, and mobile security. Based on Debian 13 with multiple specialized editions.
 
 ### Online resources
 


### PR DESCRIPTION
## NullSec Linux

A security-focused Linux distribution with 135+ pre-installed tools.

### Key Features
- **135+ Security Tools** across 13 categories
- **9 Specialized Editions**: Standard, Cloud, AI/ML, Hardware, Automotive, Mobile, Forensics, Live, Minimal
- **4 Architectures**: AMD64, ARM64, RISC-V, Apple Silicon
- **Debian 13 Base** with Kernel 6.8 LTS
- **Calamares Installer** for easy installation

### Why Include?
NullSec Linux fills a unique niche with specialized editions for:
- Cloud security (AWS, GCP, Azure, Kubernetes)
- AI/ML security (LLM red teaming, model auditing)
- Hardware hacking (SDR, RFID, JTAG)
- Automotive security (CAN bus, OBD-II)

### Links
- **GitHub**: https://github.com/bad-antics/nullsec-linux
- **Website**: https://bad-antics.github.io
- **Release**: https://github.com/bad-antics/nullsec-linux/releases/tag/v5.0.0
- **Documentation**: https://github.com/bad-antics/nullsec-wiki

This addition belongs in the **Operating Systems > Privacy & Security** section alongside Qubes OS, Whonix, and Tails.