### PR TITLE
Add NullKia Mobile Security Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [frida](https://github.com/frida/frida) - Dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers.
 - [UDcide](https://github.com/UDcide/udcide) - Android Malware Behavior Editor.
 - [reFlutter](https://github.com/ptswarm/reFlutter) - Flutter Reverse Engineering Framework
+- [NullKia](https://github.com/bad-antics/nullkia) - Mobile Security Framework with bootloader unlock, firmware extraction, baseband exploitation across 500+ devices from 18 manufacturers.
 
 ### Forensics
 


### PR DESCRIPTION
## Description
Adding NullKia to the Mobile / Android / iOS section.

**NullKia** is a comprehensive mobile security framework supporting 500+ devices across 18 manufacturers with tools for:
- Bootloader unlock & bypass
- Firmware extraction & analysis  
- Baseband/modem exploitation (Shannon, Exynos, Qualcomm)
- eSIM/eUICC provisioning
- iOS checkm8 toolchain (iOS 17/18)
- Android 14/15 bypass techniques

Repository: https://github.com/bad-antics/nullkia