### PR TITLE
Add NullSec Android to Mobile section

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [frida](https://github.com/frida/frida) - Dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers.
 - [UDcide](https://github.com/UDcide/udcide) - Android Malware Behavior Editor.
 - [reFlutter](https://github.com/ptswarm/reFlutter) - Flutter Reverse Engineering Framework
+- [NullSec Android](https://github.com/bad-antics/nullsec-android) - Android security testing toolkit with APK analysis, runtime hooking, and vulnerability scanning capabilities.
 
 ### Forensics
 


### PR DESCRIPTION
## Description
Adding NullSec Android to the Mobile / Android / iOS section.

**NullSec Android** is an Android security testing toolkit featuring:
- APK analysis and reverse engineering
- Runtime hooking with Frida integration
- Vulnerability scanning
- Traffic interception
- Permission analysis

Repository: https://github.com/bad-antics/nullsec-android