### PR TITLE
Add n01d-forge and n01d-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Meerkat](https://github.com/TonyPhipps/Meerkat) - PowerShell-based Windows artifact collection for threat hunting and incident response.
 - [Rekall](https://github.com/google/rekall) - The Rekall Framework is a completely open collection of tools, implemented in Python under the Apache and GNU General Public License, for the extraction and analysis of digital artifacts computer systems.
 - [LiME](https://github.com/504ensicsLabs/LiME.git) - Linux Memory Extractor
+- [n01d-forge](https://github.com/bad-antics/n01d-forge) - Native GUI image burner built in Rust with LUKS/VeraCrypt encryption support for creating secure forensic images and bootable drives.
 - [Maigret](https://github.com/soxoj/maigret) - Maigret collect a dossier on a person by username only, checking for accounts on a huge number of sites and gathering all the available information from web pages.
 
 ## Threat Intelligence
@@ -415,6 +416,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Qubes OS](https://www.qubes-os.org/) - Qubes OS is a free and open-source security-oriented operating system meant for single-user desktop computing.
 - [Whonix](https://www.whonix.org) - Operating System designed for anonymity.
 - [Tails OS](https://tails.boum.org/) - Tails is a portable operating system that protects against surveillance and censorship.
+- [n01d-machine](https://github.com/bad-antics/n01d-machine) - Secure VM manager with Tor/VPN integration, sandbox isolation, and network compartmentalization for anonymous operations.
 
 ### Online resources
 


### PR DESCRIPTION
## Description
Adds two Rust-based security tools to appropriate sections.

## Additions

### n01d-forge (Forensics section)
- **Description**: Native GUI image burner built in Rust with LUKS/VeraCrypt encryption support for creating secure forensic images and bootable drives
- **GitHub**: https://github.com/bad-antics/n01d-forge
- **Use case**: Secure disk imaging with encryption for forensic work

### n01d-machine (Privacy & Security section)
- **Description**: Secure VM manager with Tor/VPN integration, sandbox isolation, and network compartmentalization for anonymous operations
- **GitHub**: https://github.com/bad-antics/n01d-machine
- **Use case**: Anonymous VM management alongside Qubes OS, Whonix, and Tails

## Why Include?
- Both tools are open source
- Built with Rust for memory safety and performance
- Native GUI using egui framework
- Fill gaps in current tool coverage:
  - n01d-forge: Encryption-focused forensic imaging
  - n01d-machine: VM management with privacy focus