### PR TITLE
Add Veritensor to DevOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Teller](https://github.com/spectralops/teller) - a secrets management tool for devops and developers - manage secrets across multiple vaults and keystores from a single place.
 - [cve-ape](https://github.com/baalmor/cve-ape) - A non-intrusive CVE scanner for embedding in test and CI environments that can scan package lists and individual packages for existing CVEs via locally stored CVE database. Can also be used as an offline CVE scanner for e.g. OT/ICS. 
 - [Selefra](https://github.com/selefra/selefra) - An open-source policy-as-code software that provides analytics for multi-cloud and SaaS.
+- [Veritensor](https://github.com/ArseniiBrazhnyk/Veritensor) - Zero-trust security scanner for AI models (Pickle, PyTorch). Detects malware, verifies integrity, licenses and signs artifacts.
 
 ## Terminal
 


### PR DESCRIPTION
Hi! I would like to add Veritensor to the DevOps / Security tools section.

It is an open-source DevSecOps tool built specifically for the AI Supply Chain. It secures ML pipelines by scanning artifacts that traditional SAST tools miss.

*   **Repo:** https://github.com/arsbr/Veritensor
*   **License:** Apache 2.0

**Proposed entry:**
- [Veritensor](https://github.com/arsbr/Veritensor) - Anti-virus for the AI Supply Chain. Scans models (Pickle, PyTorch) for RCE, RAG documents/datasets for prompt injections, and Jupyter notebooks for secrets.

Thank you!