### PR TITLE
Add WAFtester to Web Scanning / Pentesting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Trust Scan](https://github.com/undeadlist/trust-scan) - URL security scanner with WHOIS, SSL, threat intelligence (URLhaus, PhishTank, Spamhaus), and 40+ scam/phishing pattern detection. Includes optional AI analysis via Ollama. ([Demo](https://aibuilds.net))
 - [react2shell-scanner](https://github.com/nxgn-kd01/react2shell-scanner) - Detect CVE-2025-55182 (React2Shell) RCE vulnerability in React Server Components. Scans React 19.x and Next.js projects for critical remote code execution flaws.
 - [shai-hulud-scanner](https://github.com/nxgn-kd01/shai-hulud-scanner) - Detect indicators of compromise from the Shai Hulud 2.0 npm supply chain attack that compromised 796+ packages. Performs comprehensive security checks for malicious files, hashes, and patterns.
+- [WAFtester](https://github.com/waftester/waftester) - WAF security testing CLI that fingerprints 197+ WAF vendors, benchmarks rule coverage with quantitative scoring, and automates bypass discovery with 70+ evasion techniques.
 
 
 ### Runtime Application Self-Protection


### PR DESCRIPTION
Hi! I'd like to add [WAFtester](https://github.com/waftester/waftester) to the Web > Scanning / Pentesting section.

**WAFtester** is an open-source CLI tool for WAF security testing that:
- Fingerprints 197+ WAF vendors
- Benchmarks WAF rule coverage with quantitative scoring (F1, MCC)
- Automates bypass discovery with 70+ evasion techniques
- Outputs SARIF, SonarQube, and GitLab SAST for CI/CD integration

GitHub: https://github.com/waftester/waftester

Thank you for maintaining this list!