### PR TITLE
Add CrowdSec Blocklist Import to Threat Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [PhishStats](https://phishstats.info/) - Phishing Statistics with search for IP, domain and website title.
 - [Threat Jammer](https://threatjammer.com) - REST API service that allows developers, security engineers, and other IT professionals to access curated threat intelligence data from a variety of sources.
 - [Cyberowl](https://github.com/karimhabush/cyberowl) - A daily updated summary of the most frequent types of security incidents currently being reported from different sources.
+- [crowdsec-blocklist-import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) - Aggregates free threat intelligence feeds into CrowdSec decisions with daemon mode and Prometheus metrics.
 
 ## Social Engineering
 


### PR DESCRIPTION
## What

Adds [crowdsec-blocklist-import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) to the Threat Intelligence section.

## About the tool

crowdsec-blocklist-import aggregates free threat intelligence blocklists (AbuseIPDB, Spamhaus DROP/EDROP, FireHOL, Tor exit nodes, etc.) and imports them as CrowdSec decisions. It runs as a daemon with configurable refresh intervals and exposes Prometheus metrics for monitoring.

## Why Threat Intelligence?

The tool is fundamentally a threat intel feed aggregator — it pulls from multiple OSINT sources and normalizes them into actionable decisions. This fits alongside tools like IntelMQ, CIFv2, and MISP that also aggregate and process threat intelligence feeds.

## Activity

- 185 stars
- Actively maintained (last updated March 2026)
- Written in Go, distributed as Docker image and binary