### PR TITLE
Add ReleaseRun CVE badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Sigma2KQL](https://github.com/Khadinxc/Sigma2KQL) - A repository of all SIGMA rules converted to KQL that runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository.
 - [Sigma2SPL](https://github.com/Khadinxc/Sigma2SPL) - A repository of all SIGMA rules converted to SPL that runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository.
 - [TerraSigma](https://github.com/Khadinxc/TerraSigma) - A repository of all SIGMA rules converted to Microsoft Sentinel Terraform Scheduled analytic resources. The repository runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository. Proper entity mapping is completed for the rules to ensure the repo is plug-and-play.
+- [ReleaseRun](https://releaserun.com/) - Embeddable badges showing CVE severity counts, EOL status, and version health for 300+ software products.
 
 ### IDS / IPS / Host IDS / Host IPS
 


### PR DESCRIPTION
ReleaseRun provides embeddable SVG badges showing CVE counts per software version. Useful for security documentation and README files.

Example:
![K8s CVE](https://img.releaserun.com/badge/cve/kubernetes/1.34.svg)
![Python CVE](https://img.releaserun.com/badge/cve/python/3.12.svg)

Covers 300+ products including Kubernetes, Python, Node.js, Go, Docker, PostgreSQL, and more.

Website: https://releaserun.com
Badge builder: https://releaserun.com/badges/builder/