### PR TITLE
Add releaserun - dependency EOL and CVE detection CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Teller](https://github.com/spectralops/teller) - a secrets management tool for devops and developers - manage secrets across multiple vaults and keystores from a single place.
 - [cve-ape](https://github.com/baalmor/cve-ape) - A non-intrusive CVE scanner for embedding in test and CI environments that can scan package lists and individual packages for existing CVEs via locally stored CVE database. Can also be used as an offline CVE scanner for e.g. OT/ICS. 
 - [Selefra](https://github.com/selefra/selefra) - An open-source policy-as-code software that provides analytics for multi-cloud and SaaS.
+- [releaserun](https://github.com/Releaserun/releaserun-cli) - CLI tool to detect end-of-life dependencies and known CVEs in your project's technology stack. Supports 300+ products.
 
 ## Terminal
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Sigma2KQL](https://github.com/Khadinxc/Sigma2KQL) - A repository of all SIGMA rules converted to KQL that runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository.
 - [Sigma2SPL](https://github.com/Khadinxc/Sigma2SPL) - A repository of all SIGMA rules converted to SPL that runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository.
 - [TerraSigma](https://github.com/Khadinxc/TerraSigma) - A repository of all SIGMA rules converted to Microsoft Sentinel Terraform Scheduled analytic resources. The repository runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository. Proper entity mapping is completed for the rules to ensure the repo is plug-and-play.
+- [ReleaseRun](https://releaserun.com/) - Embeddable badges showing CVE severity counts, EOL status, and version health for 300+ software products.
 
 ### IDS / IPS / Host IDS / Host IPS
 


### PR DESCRIPTION
Adds [releaserun](https://github.com/Releaserun/releaserun-cli) to the DevOps section.

Supply chain security tool that scans dependency files (package.json, requirements.txt, go.mod, etc.) and flags end-of-life runtimes and known CVEs. Useful for CI pipelines to enforce minimum health grades: `npx releaserun ci --fail-on D`.

Checks 300+ products against endoflife.date and CVE databases.