### PR TITLE
Add OopsSec Store to Docker Images for Penetration Testing & Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - `docker pull jeroenwillemsen/wrongsecrets`- [OWASP WrongSecrets](https://hub.docker.com/r/jeroenwillemsen/wrongsecrets)
 - `docker run -dit --name trd -p 8081:80 cylabs/cy-threat-response` - [Cyware Threat Response Docker](https://hub.docker.com/r/cylabs/cy-threat-response)
 - `docker-compose -d up` - [cicd-goat](https://github.com/cider-security-research/cicd-goat)
+- `docker run -p 3000:3000 leogra/oss-oopssec-store` - [OopsSec Store](https://hub.docker.com/r/leogra/oss-oopssec-store) - An intentionally vulnerable e-commerce app for learning web security (open-source).
 
 ## Endpoint
 


### PR DESCRIPTION
## Summary

This PR adds [OopsSec Store](https://github.com/kOaDT/oss-oopssec-store) to the Docker Images for Penetration Testing & Security section.

OopsSec Store is an open-source, intentionally vulnerable e-commerce application built with Next.js and React. It provides a realistic environment to learn and practice web application security testing, including OWASP Top 10 vulnerabilities, API security flaws, and modern frontend attack vectors.

Docker image: https://hub.docker.com/r/leogra/oss-oopssec-store
