### PR TITLE
Add ReleaseRun Security Scanners to DevOps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,8 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [cve-ape](https://github.com/baalmor/cve-ape) - A non-intrusive CVE scanner for embedding in test and CI environments that can scan package lists and individual packages for existing CVEs via locally stored CVE database. Can also be used as an offline CVE scanner for e.g. OT/ICS. 
 - [Selefra](https://github.com/selefra/selefra) - An open-source policy-as-code software that provides analytics for multi-cloud and SaaS.
 
+- [ReleaseRun Security Scanners](https://releaserun.com/tools/security/) - Browser-based security scanners for Terraform, Kubernetes YAML, Docker Compose, and GitHub Actions workflows. Paste a config file and get an A–F security grade with specific misconfigurations flagged (hardcoded credentials, open ports, privileged containers, missing permissions, supply-chain attack vectors). No install required.
+
 ## Terminal
 
 * [shellfirm](https://github.com/kaplanelad/shellfirm) - It is a handy utility to help avoid running dangerous commands with an extra approval step. You will immediately get a small prompt challenge that will double verify your action when risky patterns are detected.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Sigma2KQL](https://github.com/Khadinxc/Sigma2KQL) - A repository of all SIGMA rules converted to KQL that runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository.
 - [Sigma2SPL](https://github.com/Khadinxc/Sigma2SPL) - A repository of all SIGMA rules converted to SPL that runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository.
 - [TerraSigma](https://github.com/Khadinxc/TerraSigma) - A repository of all SIGMA rules converted to Microsoft Sentinel Terraform Scheduled analytic resources. The repository runs on a weekly schedule to update the repository and align with the up to date version of the SIGMA rules repository. Proper entity mapping is completed for the rules to ensure the repo is plug-and-play.
+- [ReleaseRun](https://releaserun.com/) - Embeddable badges showing CVE severity counts, EOL status, and version health for 300+ software products.
 
 ### IDS / IPS / Host IDS / Host IPS
 


### PR DESCRIPTION
## What this adds

**[ReleaseRun Security Scanners](https://releaserun.com/tools/security/)** — A suite of browser-based security scanners for infrastructure-as-code and DevSecOps workflows.

### Tools included in the suite:
- **Terraform Security Scanner** — checks `.tf` files for hardcoded AWS credentials, open SSH/DB ports on 0.0.0.0/0, public S3 buckets, unencrypted RDS/EBS, missing `deletion_protection`
- **Kubernetes YAML Security Linter** — 12 checks: `runAsRoot`, privileged containers, missing resource limits, `allowPrivilegeEscalation`, hardcoded secrets in env vars, no seccomp profile
- **Docker Compose Security Checker** — Docker socket mounts, `network_mode: host`, privileged containers, DB ports exposed to 0.0.0.0, mutable image tags
- **GitHub Actions Security Checker** — supply chain attack vectors (`pull_request_target` + `checkout`), missing `permissions` block, hardcoded secrets, `persist-credentials: true`

### Why it belongs here:
Fits the DevOps section alongside Trivy and ansible-os-hardening — these are tools for developers to find security misconfigurations in their own IaC before they reach production. Browser-based: no install, no CLI setup needed.

Added to the **DevOps** section.