### PR TITLE
Add crowdsec-unifi-bouncer to IDS / IPS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [SSHGuard](http://www.sshguard.net/) - A software to protect services in addition to SSH, written in C
 - [Lynis](https://cisofy.com/lynis/) - an open source security auditing tool for Linux/Unix.
 - [CrowdSec](https://github.com/crowdsecurity/crowdsec) - CrowdSec is a free, modern & collaborative behavior detection engine, coupled with a global IP reputation network. It stacks on Fail2Ban's philosophy but is IPV6 compatible and 60x faster (Go vs Python), uses Grok patterns to parse logs and YAML scenario to identify behaviors. CrowdSec is engineered for modern Cloud / Containers / VM based infrastructures (by decoupling detection and remediation). Once detected, you can remedy threats with various bouncers (firewall block, nginx http 403, Captchas, etc.) while the aggressive IPs can be sent to CrowdSec for curation before being shared among all users to further strengthen the community
+- [crowdsec-unifi-bouncer](https://github.com/wolffcatskyy/crowdsec-unifi-bouncer) - CrowdSec firewall bouncer for UniFi OS devices with automatic recovery from firmware updates.
 - [wazuh](https://github.com/wazuh/wazuh) - Wazuh is a free and open source XDR platform used for threat prevention, detection, and response. It is capable of protecting workloads across on-premises, virtualized, containerized, and cloud-based environments. Great tool foor all kind of deployments, it includes SIEM capabitilies (indexing + searching + WUI).
 
 ### Honey Pot / Honey Net


### PR DESCRIPTION
## What

Adds [crowdsec-unifi-bouncer](https://github.com/wolffcatskyy/crowdsec-unifi-bouncer) to the IDS / IPS / Host IDS / Host IPS section, right after the CrowdSec entry.

## About the tool

crowdsec-unifi-bouncer is a CrowdSec firewall bouncer purpose-built for UniFi OS devices (UDM, UDR, UXG). It translates CrowdSec decisions into UniFi firewall rules and automatically recovers from firmware updates that wipe custom rules — a common pain point for UniFi users running CrowdSec.

## Why IDS / IPS?

CrowdSec bouncers are the enforcement layer of the CrowdSec IDS ecosystem. This bouncer extends CrowdSec protection to UniFi network appliances, making it a natural companion to the existing CrowdSec entry in this section.

## Activity

- 23 stars
- Actively maintained (last updated March 2026)
- Written in Go, distributed as Docker image and binary
- Solves a well-known gap in the CrowdSec ecosystem for Ubiquiti users