### PR TITLE
Add CrowdSec Blocklist Import to Threat Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [PhishStats](https://phishstats.info/) - Phishing Statistics with search for IP, domain and website title.
 - [Threat Jammer](https://threatjammer.com) - REST API service that allows developers, security engineers, and other IT professionals to access curated threat intelligence data from a variety of sources.
 - [Cyberowl](https://github.com/karimhabush/cyberowl) - A daily updated summary of the most frequent types of security incidents currently being reported from different sources.
+- [crowdsec-blocklist-import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) - Aggregates free threat intelligence feeds into CrowdSec decisions with daemon mode and Prometheus metrics.
 
 ## Social Engineering
 


### PR DESCRIPTION
Adds [crowdsec-blocklist-import](https://github.com/wolffcatskyy/crowdsec-blocklist-import) to the Threat Intelligence section — aggregates 36 free threat feeds into CrowdSec for 120k+ unique IP blocks.

Resubmitted from #372.