### PR TITLE
Add brood-box to DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Teller](https://github.com/spectralops/teller) - a secrets management tool for devops and developers - manage secrets across multiple vaults and keystores from a single place.
 - [cve-ape](https://github.com/baalmor/cve-ape) - A non-intrusive CVE scanner for embedding in test and CI environments that can scan package lists and individual packages for existing CVEs via locally stored CVE database. Can also be used as an offline CVE scanner for e.g. OT/ICS. 
 - [Selefra](https://github.com/selefra/selefra) - An open-source policy-as-code software that provides analytics for multi-cloud and SaaS.
+- [brood-box](https://github.com/stacklok/brood-box) - A CLI tool for running AI coding agents inside hardware-isolated microVMs with workspace snapshot isolation, egress control, and MCP authorization profiles.
 
 ## Terminal
 


### PR DESCRIPTION
## Summary

[brood-box](https://github.com/stacklok/brood-box) is a CLI tool for running AI coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs. It fits the DevOps section as infrastructure security tooling, providing:

- **Workspace snapshot isolation** — COW snapshots are created before the VM starts; changes are diffed and reviewed before being flushed back
- **Egress control** — DNS-aware network policies restrict outbound traffic from the sandboxed agent
- **MCP authorization profiles** — Cedar-based policies control what MCP operations the agent can perform (full-access, observe, safe-tools, or custom)

This gives DevOps and platform teams a secure way to let AI agents operate on codebases without granting them unrestricted host access.

🤖 Generated with [Claude Code](https://claude.ai/code) and [Brood Box](https://github.com/stacklok/brood-box)