### PR TITLE
Add Pentest Mindmap — interactive command reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Grokking Web Application Security](https://www.manning.com/books/grokking-web-application-security) - A book about building web apps that are ready for and resilient to any attack.
 
 ## Other Awesome Lists
+- [Pentest Mindmap](https://pentestmindmap.com/en) - Interactive mindmap with 11,600+ pentesting commands across 32 categories. Searchable with one-click copy.
 
 ### Other Security Awesome Lists
 


### PR DESCRIPTION
Adding Pentest Mindmap — an interactive web-based mindmap with 11,600+ pentesting commands organized across 32 categories.

A searchable, visual reference tool for pentesters. Commands are organized in a D3.js interactive mindmap covering recon, web hacking, AD, privesc, cloud, post-exploitation, and 26 more categories. Each command includes a description.

Trilingual (EN/FR/ES). Free 7-day trial available.