### PR TITLE
Add NullSec LogReaper and NullSec Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [mig](http://mig.mozilla.org/) - MIG is a platform to perform investigative surgery on remote endpoints. It enables investigators to obtain information from large numbers of systems in parallel, thus accelerating investigation of incidents and day-to-day operations security.
 - [ir-rescue](https://github.com/diogo-fernan/ir-rescue) - *ir-rescue* is a Windows Batch script and a Unix Bash script to comprehensively collect host forensic data during incident response.
 - [Logdissect](https://github.com/dogoncouch/logdissect) - CLI utility and Python API for analyzing log files and other data.
+- [NullSec LogReaper](https://github.com/bad-antics/nullsec-logreaper) - DFIR log analysis and threat detection tool with pattern matching, timeline reconstruction, and automated IOC extraction across syslog, auth, Windows Event, and cloud audit logs.
 - [Meerkat](https://github.com/TonyPhipps/Meerkat) - PowerShell-based Windows artifact collection for threat hunting and incident response.
 - [Rekall](https://github.com/google/rekall) - The Rekall Framework is a completely open collection of tools, implemented in Python under the Apache and GNU General Public License, for the extraction and analysis of digital artifacts computer systems.
 - [LiME](https://github.com/504ensicsLabs/LiME.git) - Linux Memory Extractor
@@ -415,6 +416,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Qubes OS](https://www.qubes-os.org/) - Qubes OS is a free and open-source security-oriented operating system meant for single-user desktop computing.
 - [Whonix](https://www.whonix.org) - Operating System designed for anonymity.
 - [Tails OS](https://tails.boum.org/) - Tails is a portable operating system that protects against surveillance and censorship.
+- [NullSec Linux](https://github.com/bad-antics/nullsec-linux) - Security-focused Linux distribution built for penetration testing and DFIR, featuring pre-configured offensive and defensive tooling with hardened defaults.
 
 ### Online resources
 


### PR DESCRIPTION
## Additions

### NullSec LogReaper → Forensics
- **Repository:** https://github.com/bad-antics/nullsec-logreaper (77+ ★)
- **Description:** DFIR log analysis and threat detection tool with pattern matching, timeline reconstruction, and automated IOC extraction across syslog, auth, Windows Event, and cloud audit logs.
- **Why it belongs:** LogReaper fills the gap between raw log parsers (like Logdissect) and full SIEM platforms — it's purpose-built for incident responders who need fast IOC extraction and timeline correlation from heterogeneous log sources.

### NullSec Linux → Operating Systems > Privacy & Security
- **Repository:** https://github.com/bad-antics/nullsec-linux (48+ ★)
- **Description:** Security-focused Linux distribution for penetration testing and DFIR, featuring pre-configured offensive and defensive tooling with hardened defaults.
- **Why it belongs:** Alongside Kali, Tsurugi, Qubes, Whonix, and Tails, NullSec Linux provides a ready-to-deploy security distribution that bridges offensive and defensive use cases.

Both projects are actively maintained and open source.