### PR TITLE
Add procscope to Forensics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Rekall](https://github.com/google/rekall) - The Rekall Framework is a completely open collection of tools, implemented in Python under the Apache and GNU General Public License, for the extraction and analysis of digital artifacts computer systems.
 - [LiME](https://github.com/504ensicsLabs/LiME.git) - Linux Memory Extractor
 - [Maigret](https://github.com/soxoj/maigret) - Maigret collect a dossier on a person by username only, checking for accounts on a huge number of sites and gathering all the available information from web pages.
+- [procscope](https://mutasem-mk4.github.io/procscope/) - A process-scoped runtime investigator using eBPF to trace process lifecycle, file activity, and network connections.
 
 ## Threat Intelligence
 


### PR DESCRIPTION
Adding procscope to the Forensics section.

procscope is an open-source process-scoped runtime investigator using eBPF to trace process lifecycle, file activity, and network connections. It is purpose-built for incident response and runtime investigation in Linux and Kubernetes environments.

- Website: https://mutasem-mk4.github.io/procscope/
- GitHub: https://github.com/Mutasem-mk4/procscope

The project maintains high standards with 82%+ core test coverage.