### PR TITLE
Add Akira - AI pentest co-pilot to Scanning/Pentesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 
 ### Scanning / Pentesting
 
+- [Akira](https://github.com/Kalp1774/akira) - Open-source AI pentest co-pilot with 12 phase-chained attack skills. Evidence-gated findings with zero hallucinations. Runs natively in Claude Code, Gemini CLI, and Cursor.
 - [OpenVAS](http://www.openvas.org/) - OpenVAS is a framework of several services and tools offering a comprehensive and powerful vulnerability scanning and vulnerability management solution.
 - [Metasploit Framework](https://github.com/rapid7/metasploit-framework) - A tool for developing and executing exploit code against a remote target machine. Other important sub-projects include the Opcode Database, shellcode archive and related research.
 - [Kali](https://www.kali.org/) - Kali Linux is a Debian-derived Linux distribution designed for digital forensics and penetration testing. Kali Linux is preinstalled with numerous penetration-testing programs, including nmap (a port scanner), Wireshark (a packet analyzer), John the Ripper (a password cracker), and Aircrack-ng (a software suite for penetration-testing wireless LANs).


### PR DESCRIPTION
## What is Akira?

[Akira](https://github.com/Kalp1774/akira) is an open-source AI pentest co-pilot that runs natively inside Claude Code, Gemini CLI, and Cursor.

**How it works differently:**
- Maintains a `session.json` across phases so each skill (recon, secrets, exploit, report) builds on the previous one's findings - no stateless prompts
- Every finding requires raw HTTP request/response as evidence before being flagged - the model cannot report a vulnerability it hasn't proven
- 12 skills covering the full engagement lifecycle: subdomains, live hosts, JS secret hunting, XSS/SQLi/SSRF/SSTI/XXE, JWT attacks, race conditions, AD chains, cloud audit, OAuth, CTF
- No server, no pre-install of 40 tools required - runs inside your existing AI coding environment

MIT licensed, free, actively maintained.