### PR TITLE
Add DDactic - automated DDoS resilience testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Deepfence ThreatMapper](https://github.com/deepfence/ThreatMapper) - Apache v2, powerful runtime vulnerability scanner for kubernetes, virtual machines and serverless.
 - [Deepfence SecretScanner](https://github.com/deepfence/SecretScanner) - Find secrets and passwords in container images and file systems.
 - [Cognito Scanner](https://github.com/padok-team/cognito-scanner) - CLI tool to pentest Cognito AWS instance. It implements three attacks: unwanted account creation, account oracle and identity pool escalation
+- [DDactic](https://ddactic.net) - Automated DDoS resilience testing. Generates per-vector attack plans from passive recon and runs L3/L4/L7 simulations from a 23+ cloud-provider bot fleet (H2 RST, Slowloris, QUIC INITIAL, ATO replay).
 
 ### Monitoring / Logging
 - [BoxyHQ](https://github.com/retracedhq/retraced) - Open source API for security and compliance audit logging.


### PR DESCRIPTION
DDactic is an automated DDoS resilience testing platform.

- Free passive scan: subdomain enumeration, CDN/WAF detection, port profile, TLS fingerprint, per-vector attack plan
- Active simulation: bot fleet across 23+ cloud providers, covers L3/L4/L7 (HTTP/2 Rapid Reset, Slowloris-headers, QUIC INITIAL, ATO replay; ~200 vectors total)

Live at https://ddactic.net. Sits in the same category as Anevicon and Finshir already listed in this section, with broader vector coverage and per-target calibration.