### PR TITLE
Add UNPWNED (passive web security scanner) to Web > Scanning / Pentesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Trust Scan](https://github.com/undeadlist/trust-scan) - URL security scanner with WHOIS, SSL, threat intelligence (URLhaus, PhishTank, Spamhaus), and 40+ scam/phishing pattern detection. Includes optional AI analysis via Ollama. ([Demo](https://aibuilds.net))
 - [react2shell-scanner](https://github.com/nxgn-kd01/react2shell-scanner) - Detect CVE-2025-55182 (React2Shell) RCE vulnerability in React Server Components. Scans React 19.x and Next.js projects for critical remote code execution flaws.
 - [shai-hulud-scanner](https://github.com/nxgn-kd01/shai-hulud-scanner) - Detect indicators of compromise from the Shai Hulud 2.0 npm supply chain attack that compromised 796+ packages. Performs comprehensive security checks for malicious files, hashes, and patterns.
+- [UNPWNED](https://www.unpwned.io/) - Passive web security scanner for AI-built apps and indie SaaS. Runs 700+ checks in under 2 minutes and returns plain-English findings with copy-paste fix prompts for AI coding agents like Cursor, Claude, and Copilot. Detects leaked secrets, weak headers, SSL/TLS issues, DNS/email auth gaps, exposed config files, Supabase/Firebase RLS problems, and dependency CVEs.
 
 
 ### Runtime Application Self-Protection


### PR DESCRIPTION
UNPWNED is a **passive** web security scanner aimed at indie hackers and developers shipping AI-generated code. It runs 700+ automated checks (SSL/TLS, security headers, leaked secrets, exposed config files, Supabase/Firebase RLS, DNS auth gaps, dependency CVEs, etc.) in under 2 minutes and returns plain-English findings with copy-paste fix prompts for AI coding agents like Cursor, Claude, and Copilot.

Note on positioning: UNPWNED is explicitly **not** a pentest tool or pentest replacement. It is a passive automated scanner that probes the same surface a normal web visitor would see (active probing in Deep Scan requires domain ownership verification). I added it to the Scanning / Pentesting section because that is where similar passive scanners already live in this list (Trust Scan, is-website-vulnerable, react2shell-scanner, shai-hulud-scanner). Happy to move it if there is a more accurate sub-section.

- Website: https://www.unpwned.io
- Open-source CLI: https://github.com/razazu/unpwned-cli (npm: `unpwned`)