### PR TITLE
Add Networking from Scratch to EBooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [Spring Security in Action, Second Edition](https://www.manning.com/books/spring-security-in-action-second-edition) - A book about designing and developing Spring applications that are secure right from the start.
 - [Azure Security](https://www.manning.com/books/azure-security-2) - A practical guide to the native security services of Microsoft Azure.
 - [Node.js Secure Coding: Defending Against Command Injection Vulnerabilities](https://www.nodejs-security.com) - Learn secure coding conventions in Node.js by executing command injection attacks on real-world npm packages and analyzing vulnerable code.
+- [Networking from Scratch](https://github.com/TanayK07/networking-from-scratch) - 289 hands-on lessons in C and Python covering the full network stack from raw bytes to eBPF, including packet capture, protocol parsing, and network security fundamentals.
 - [Node.js Secure Coding: Prevention and Exploitation of Path Traversal Vulnerabilities](https://www.nodejs-security.com/book/path-traversal) - Master secure coding in Node.js with real-world vulnerable dependencies and experience firsthand secure coding techniques against Path Traversal vulnerabilities.
 - [Grokking Web Application Security](https://www.manning.com/books/grokking-web-application-security) - A book about building web apps that are ready for and resilient to any attack.
 


### PR DESCRIPTION
## Add Networking from Scratch to EBooks

[Networking from Scratch](https://github.com/TanayK07/networking-from-scratch) is a free, open-source curriculum of 289 hands-on lessons in C and Python that builds the entire network stack from the ground up.

### Security-relevant content includes:

- **Packet capture & analysis** — raw sockets, libpcap, BPF filters, and protocol dissection
- **TLS/SSL** — certificate parsing, handshake internals, and cipher suite negotiation
- **XDP & eBPF** — high-performance packet filtering and in-kernel security monitoring
- **Raw sockets** — crafting and injecting frames at Layers 2–4
- **Network security fundamentals** — firewall rules, ARP spoofing detection, DNS security, and protocol-level vulnerability analysis

This adds the entry in alphabetical order within the EBooks section.