### PR TITLE
Add net-benchmark to Monitoring / Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [opensnitch](https://github.com/evilsocket/opensnitch) - OpenSnitch is a GNU/Linux port of the Little Snitch application firewall
 - [wazuh](https://github.com/wazuh/wazuh) - Wazuh is a free and open source platform used for threat prevention, detection, and response. It is capable of monitoring file system  changes, system calls and inventory changes.
 - [Matano](https://github.com/matanolabs/matano): Open source serverless security lake platform on AWS that lets you ingest, store, and analyze petabytes of security data into an Apache Iceberg data lake and run realtime Python detections as code.
+- [net-benchmark](https://github.com/net-benchmark/net-benchmark) - DNS/HTTP/SSL benchmarking and diagnostics CLI.
 - [Falco](https://falco.org/) - The cloud-native runtime security project and de facto Kubernetes threat detection engine now part of the CNCF.
 - [VAST](https://github.com/tenzir/vast) - Open source security data pipeline engine for structured event data, supporting high-volume telemetry ingestion, compaction, and retrieval; purpose-built for security content execution, guided threat hunting, and large-scale investigation.
 - [Substation](https://github.com/brexhq/substation) - Substation is a cloud native data pipeline and transformation toolkit written in Go.


### PR DESCRIPTION
Add net-benchmark to the Monitoring / Logging section.

net-benchmark is an open-source DNS/HTTP/SSL benchmarking and diagnostics CLI.
It measures resolver performance, DNSSEC behavior, DoH/DoT endpoints, and TLS
timing to support network-layer monitoring and analysis.

Project: https://github.com/net-benchmark/net-benchmark
