### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [passpie](https://github.com/marcwebbie/passpie) - Multiplatform command-line password manager
 - [Vault](https://www.vaultproject.io/) - An encrypted datastore secure enough to hold environment and application secrets.
 - [LunaSec](https://github.com/lunasec-io/lunasec) - Database for PII with automatic encryption/tokenization, sandboxed components for handling data, and centralized authorization controls.
-- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable agent queries across approved data sources.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable queries for agents across approved data sources.
 
 ## Fraud prevention
 

--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [passpie](https://github.com/marcwebbie/passpie) - Multiplatform command-line password manager
 - [Vault](https://www.vaultproject.io/) - An encrypted datastore secure enough to hold environment and application secrets.
 - [LunaSec](https://github.com/lunasec-io/lunasec) - Database for PII with automatic encryption/tokenization, sandboxed components for handling data, and centralized authorization controls.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted data access gateway for databases, analytics tools, and APIs, with centralized credentials, read-only query validation, query limits, and audit logs.
 
 ## Fraud prevention
 

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Provided data: IPv4 hosts, sub/domains/whois, ports/banners/protocols, technolog
 - [passpie](https://github.com/marcwebbie/passpie) - Multiplatform command-line password manager
 - [Vault](https://www.vaultproject.io/) - An encrypted datastore secure enough to hold environment and application secrets.
 - [LunaSec](https://github.com/lunasec-io/lunasec) - Database for PII with automatic encryption/tokenization, sandboxed components for handling data, and centralized authorization controls.
-- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted data access gateway for databases, analytics tools, and APIs, with centralized credentials, read-only query validation, query limits, and audit logs.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable agent queries across approved data sources.
 
 ## Fraud prevention
 


### PR DESCRIPTION
Adds OneQuery to Datastores.

OneQuery is a self-hosted gateway for safe, auditable queries for agents across approved data sources.

Guideline check:
- One link in this PR.
- Link works and no duplicate OneQuery entry was found before submission.
- Description is short, neutral, and follows the existing list format.
- Disclosure: I am affiliated with Wordbricks/OneQuery.