### PR TITLE
Add DMARCTrust as a deliverability and authentication monitoring option

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ Thanks to all [contributors](https://github.com/sbilly/awesome-security/graphs/c
 - [Spam Scanner](https://github.com/spamscanner) - Anti-Spam Scanning Service and Anti-Spam API by [@niftylettuce](https://github.com/niftylettuce).
 - [rspamd](https://github.com/rspamd/rspamd) - Fast, free and open-source spam filtering system.
 - [SpamAssassin](https://spamassassin.apache.org/) - A powerful and popular email spam filter employing a variety of detection technique.
-- [Scammer-List](https://scammerlist.now.sh/) - A free open source AI based Scam and Spam Finder with a free API
+- [Scammer-List](https://scammerlist.now.sh/) - A free open source AI based Scam and Spam Finder with a free API.
+- [DMARCTrust](https://www.dmarctrust.com/) - DMARC report analysis, email authentication monitoring (SPF, DKIM, BIMI, MTA-STS, TLS-RPT), and deliverability analytics.
 
 ### Docker Images for Penetration Testing & Security
 


### PR DESCRIPTION
Hello,

I'm the owner of DMARCTrust (https://www.dmarctrust.com), a SaaS platform for DMARC report processing, email authentication monitoring, and deliverability analytics. We help domains secure their email infrastructure by monitoring and hardening DMARC, SPF, DKIM, BIMI, MTA-STS, and TLS-RPT configurations.

I'd like to suggest adding our tool to the **Anti-Spam** section of the `Awesome Security` list. Since DMARC and related protocols are the modern standard for domain anti-spoofing and anti-spam verification, our tool fits perfectly here to help administrators audit their setups.

The tool offers free-forever tiers for individual domains, making it fully accessible to developers, sysadmins, and security researchers.

Here is the proposed line (see my PR) to append under the `### Anti-Spam` category:

- [DMARCTrust](https://www.dmarctrust.com/) - SaaS platform for DMARC report analysis, email authentication monitoring (SPF, DKIM, BIMI, MTA-STS, TLS-RPT), and deliverability analytics.

Thank you for maintaining this excellent security resource!