### PR TITLE
Add ansede-static to Static Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,4 +525,4 @@ Your contributions are always welcome!
 
 
 ## Static Analysis
-- [ansede-static](https://github.com/mattybellx/Ansede) — Offline SAST with 96.3% CVE recall. Detects IDOR, auth bypass, and ownership flaws that Semgrep and Bandit miss. Python/JS/Go/Java/C#.
+- [ansede-static](https://github.com/mattybellx/Ansede) - Offline SAST tool to detect IDOR, authorization bypass, and ownership issues. Supports Python/JavaScript/Go/Java/C#.

--- a/README.md
+++ b/README.md
@@ -522,3 +522,7 @@ Other amazingly awesome lists:
 ## [Contributing](contributing.md)
 
 Your contributions are always welcome!
+
+
+## Static Analysis
+- [ansede-static](https://github.com/mattybellx/Ansede) — Offline SAST with 96.3% CVE recall. Detects IDOR, auth bypass, and ownership flaws that Semgrep and Bandit miss. Python/JS/Go/Java/C#.


### PR DESCRIPTION
Adds [ansede-static](https://github.com/mattybellx/Ansede) — an offline SAST with 96.3% CVE recall. Detects IDOR and auth bypass flaws. MIT licensed.